### PR TITLE
Доработка бутлоадера для настройки NodeID 

### DIFF
--- a/BootLoader/Controller/Controller.c
+++ b/BootLoader/Controller/Controller.c
@@ -63,7 +63,7 @@ void CONTROL_Init()
 	CONTROL_ConfigCAN(NodeID);
 
 	// Device profile initialization
-	DEVPROFILE_Init(&CONTROL_DispatchAction, &CycleActive);
+	DEVPROFILE_Init(&CONTROL_DispatchAction, &CycleActive, NodeID);
 	DEVPROFILE_InitEPWriteService(EPWriteIndexes, EPWriteSized, EPWriteCounters, EPWriteDatas);
 	// Reset control values
 	DEVPROFILE_ResetControlSection();

--- a/BootLoader/Controller/Controller.c
+++ b/BootLoader/Controller/Controller.c
@@ -59,11 +59,7 @@ void CONTROL_Init()
 	DT_Init(EPROMService, false);
 
 	// Инициализация функций связанных с CAN NodeID
-	Int16U NodeID;
-	if((DataTable[REG_NODE_ID] == 0)||(DataTable[REG_NODE_ID] == 65535))
-		NodeID = CAN_SLAVE_NID;
-	else
-		NodeID = DataTable[REG_NODE_ID];
+	Int16U NodeID = ((DataTable[REG_NODE_ID] == 0)||(DataTable[REG_NODE_ID] == INT16U_MAX)) ? CAN_SLAVE_NID : DataTable[REG_NODE_ID];
 	CONTROL_ConfigCAN(NodeID);
 
 	// Device profile initialization

--- a/BootLoader/Controller/Controller.c
+++ b/BootLoader/Controller/Controller.c
@@ -59,7 +59,11 @@ void CONTROL_Init()
 	DT_Init(EPROMService, false);
 
 	// Инициализация функций связанных с CAN NodeID
-	Int16U NodeID = DataTable[REG_NODE_ID] ? DataTable[REG_NODE_ID] : CAN_SLAVE_NID;
+	Int16U NodeID;
+	if((DataTable[REG_NODE_ID] == 0)||(DataTable[REG_NODE_ID] == 65535))
+		NodeID = CAN_SLAVE_NID;
+	else
+		NodeID = DataTable[REG_NODE_ID];
 	CONTROL_ConfigCAN(NodeID);
 
 	// Device profile initialization

--- a/BootLoader/Platform/Constraints.c
+++ b/BootLoader/Platform/Constraints.c
@@ -13,7 +13,7 @@
 //
 const TableItemConstraint NVConstraint[DATA_TABLE_NV_SIZE] =
 									  {
-										   {0, 0, 0},							// 0
+										   {0, INT16U_MAX, 0},					// 0
 										   {0, 0, 0}							// 1
 									  };
 

--- a/BootLoader/Platform/DataTable.c
+++ b/BootLoader/Platform/DataTable.c
@@ -9,7 +9,7 @@
 
 // Constants
 //
-#define DT_EPROM_ADDRESS	0x0801F800
+#define DT_EPROM_ADDRESS	0x08007800
 
 // Variables
 //
@@ -22,8 +22,13 @@ void DT_Init(EPROMServiceConfig EPROMService, Boolean NoRestore)
 {
 	Int16U i;
 
+	EPROMServiceCfg = EPROMService;
+
 	for(i = 0; i < DATA_TABLE_SIZE; ++i)
 		DataTable[i] = 0;
+
+	if(!NoRestore)
+		DT_RestoreNVPartFromEPROM();
 }
 // ----------------------------------------
 

--- a/BootLoader/Platform/DeviceObjectDictionary.h
+++ b/BootLoader/Platform/DeviceObjectDictionary.h
@@ -24,9 +24,9 @@
 
 // REGISTERS
 //
+#define REG_NODE_ID					0	// Выставление CAN NodeID
 // No NVRAM section
 //
-#define REG_NODE_ID					0	// Выставление CAN NodeID
 #define REG_DUMMY					2	// Compatibility register
 #define REG_XOR_PC					3	// PC calculated XOR value
 //

--- a/BootLoader/Platform/DeviceObjectDictionary.h
+++ b/BootLoader/Platform/DeviceObjectDictionary.h
@@ -8,6 +8,10 @@
 
 // ACTIONS
 //
+#define ACT_SAVE_TO_ROM				200	// Сохранение пользовательских данных во FLASH процессора
+#define ACT_RESTORE_FROM_ROM		201	// Восстановление данных из FLASH
+#define ACT_RESET_TO_DEFAULT		202	// Сброс DataTable в состояние по умолчанию
+//
 #define ACT_FL_ERASE				300	// Erase flash
 #define ACT_FL_RESET_COUNTERS		301	// Reset checksum counters
 #define ACT_FL_WRITE				302	// Begin flash write
@@ -22,6 +26,7 @@
 //
 // No NVRAM section
 //
+#define REG_NODE_ID					0	// Выставление CAN NodeID
 #define REG_DUMMY					2	// Compatibility register
 #define REG_XOR_PC					3	// PC calculated XOR value
 //
@@ -44,6 +49,7 @@
 #define ERR_CONFIGURATION_LOCKED	1	// Device is locked for writing
 #define ERR_OPERATION_BLOCKED		2	// Operation can't be done due to current device state
 #define ERR_DEVICE_NOT_READY		3	// Device isn't ready to switch state
+#define ERR_WRONG_PWD				4	// Неправильный ключ
 
 
 #endif // __DEV_OBJ_DIC_H

--- a/BootLoader/Platform/DeviceProfile.c
+++ b/BootLoader/Platform/DeviceProfile.c
@@ -50,6 +50,7 @@ static volatile Boolean *MaskChangesFlag;
 // Forward functions
 //
 static void DEVPROFILE_FillWRPartDefault();
+static void DEVPROFILE_FillNVPartDefault(void);
 static Boolean DEVPROFILE_Validate16(Int16U Address, Int16U Data);
 static Boolean DEVPROFILE_DispatchAction(Int16U ActionID, pInt16U UserError);
 static Int16U DEVPROFILE_CallbackReadX(Int16U Endpoint, pInt16U *Buffer, Boolean Streamed,
@@ -210,6 +211,16 @@ static void DEVPROFILE_FillWRPartDefault()
 }
 // ----------------------------------------
 
+void DEVPROFILE_FillNVPartDefault(void)
+{
+	Int16U i;
+
+	// Write default values to data table
+	for (i = 0; i < DATA_TABLE_NV_SIZE; ++i)
+		DataTable[DATA_TABLE_NV_START + i] = NVConstraint[i].Default;
+}
+// ----------------------------------------
+
 static Boolean DEVPROFILE_Validate16(Int16U Address, Int16U Data)
 {
 	if(ENABLE_LOCKING && !UnlockedForNVWrite && (Address < DATA_TABLE_WR_START))
@@ -242,7 +253,37 @@ static Boolean DEVPROFILE_Validate16(Int16U Address, Int16U Data)
 
 static Boolean DEVPROFILE_DispatchAction(Int16U ActionID, pInt16U UserError)
 {
-	return (ControllerDispatchFunction) ? ControllerDispatchFunction(ActionID, UserError) : FALSE;
+	switch(ActionID)
+	{
+		case ACT_SAVE_TO_ROM:
+			{
+				if(ENABLE_LOCKING && !UnlockedForNVWrite)
+					*UserError = ERR_WRONG_PWD;
+				else
+					DT_SaveNVPartToEPROM();
+			}
+			break;
+		case ACT_RESTORE_FROM_ROM:
+			{
+				if(ENABLE_LOCKING && !UnlockedForNVWrite)
+					*UserError = ERR_WRONG_PWD;
+				else
+					DT_RestoreNVPartFromEPROM();
+			}
+			break;
+		case ACT_RESET_TO_DEFAULT:
+			{
+				if(ENABLE_LOCKING && !UnlockedForNVWrite)
+					*UserError = ERR_WRONG_PWD;
+				else
+					DT_ResetNVPart(&DEVPROFILE_FillNVPartDefault);
+			}
+			break;
+		default:
+			return (ControllerDispatchFunction) ? ControllerDispatchFunction(ActionID, UserError) : FALSE;
+	}
+
+	return TRUE;
 }
 // ----------------------------------------
 

--- a/BootLoader/Platform/DeviceProfile.c
+++ b/BootLoader/Platform/DeviceProfile.c
@@ -60,7 +60,7 @@ static Boolean DEVPROFILE_CallbackWriteX(Int16U Endpoint, pInt16U Buffer, Boolea
 
 // Functions
 //
-void DEVPROFILE_Init(xCCI_FUNC_CallbackAction SpecializedDispatch, volatile Boolean *MaskChanges)
+void DEVPROFILE_Init(xCCI_FUNC_CallbackAction SpecializedDispatch, volatile Boolean *MaskChanges, Int16U NodeID)
 {
 	// Save values
 	ControllerDispatchFunction = SpecializedDispatch;
@@ -84,8 +84,8 @@ void DEVPROFILE_Init(xCCI_FUNC_CallbackAction SpecializedDispatch, volatile Bool
 	// Init interface driver
 	SCCI_Init(&DEVICE_RS232_Interface, &RS232_IOConfig, &X_ServiceConfig, (pInt16U)DataTable,
 			  DATA_TABLE_SIZE, SCCI_TIMEOUT_TICKS, &RS232_EPState);
-	BCCI_Init(&DEVICE_CAN_Interface, &CAN_IOConfig, &X_ServiceConfig, (pInt16U)DataTable,
-			  DATA_TABLE_SIZE, &CAN_EPState);
+	BCCI_InitWithNodeID(&DEVICE_CAN_Interface, &CAN_IOConfig, &X_ServiceConfig, (pInt16U)DataTable,
+			  DATA_TABLE_SIZE, &CAN_EPState, NodeID);
 
 	// Set write protection
 	SCCI_AddProtectedArea(&DEVICE_RS232_Interface, DATA_TABLE_WP_START, DATA_TABLE_SIZE - 1);

--- a/BootLoader/Platform/DeviceProfile.c
+++ b/BootLoader/Platform/DeviceProfile.c
@@ -50,7 +50,7 @@ static volatile Boolean *MaskChangesFlag;
 // Forward functions
 //
 static void DEVPROFILE_FillWRPartDefault();
-static void DEVPROFILE_FillNVPartDefault(void);
+static void DEVPROFILE_FillNVPartDefault();
 static Boolean DEVPROFILE_Validate16(Int16U Address, Int16U Data);
 static Boolean DEVPROFILE_DispatchAction(Int16U ActionID, pInt16U UserError);
 static Int16U DEVPROFILE_CallbackReadX(Int16U Endpoint, pInt16U *Buffer, Boolean Streamed,
@@ -211,7 +211,7 @@ static void DEVPROFILE_FillWRPartDefault()
 }
 // ----------------------------------------
 
-void DEVPROFILE_FillNVPartDefault(void)
+void DEVPROFILE_FillNVPartDefault()
 {
 	Int16U i;
 

--- a/BootLoader/Platform/DeviceProfile.h
+++ b/BootLoader/Platform/DeviceProfile.h
@@ -15,7 +15,7 @@
 // Functions
 //
 // Initialize device profile engine
-void DEVPROFILE_Init(xCCI_FUNC_CallbackAction SpecializedDispatch, volatile Boolean *MaskChanges);
+void DEVPROFILE_Init(xCCI_FUNC_CallbackAction SpecializedDispatch, volatile Boolean *MaskChanges, Int16U NodeID);
 // Initialize endpoint service
 void DEVPROFILE_InitEPReadService(pInt16U Indexes, pInt16U Sizes, pInt16U *Counters, pInt16U *Datas);
 void DEVPROFILE_InitEPWriteService(pInt16U Indexes, pInt16U Sizes, pInt16U *Counters, pInt16U *Datas);

--- a/BootLoader/Root/BCCIxParams.h
+++ b/BootLoader/Root/BCCIxParams.h
@@ -1,0 +1,33 @@
+﻿// -----------------------------------------
+// Parameters of BCCI interface
+// ----------------------------------------
+
+#ifndef __BCCI_PARAMS_H
+#define __BCCI_PARAMS_H
+
+#include "xCCIParams.h"
+
+
+// Маска поля функции
+//
+#define CAN_FUNC_MASK				0x000003FF
+
+// Конфигурация Slave
+//
+#define CAN_SLAVE_NID				99				// Node ID устройства
+#define CAN_SLAVE_NID_MASK			0x0003FC00		// Маска Slave node ID
+#define CAN_SLAVE_NID_MPY			10				// Смещение адреса Slave
+
+// Конфигурация Master
+//
+#define CAN_MASTER_NID				0				// Node ID устройства
+#define CAN_MASTER_NID_MASK			0x03FC0000		// Маска Master node ID
+#define CAN_MASTER_NID_MPY			18				// Смещение адреса Master
+
+// CAN фильтр
+//
+#define CAN_SLAVE_FILTER_ID			(CAN_SLAVE_NID << CAN_SLAVE_NID_MPY)
+#define CAN_MASTER_FILTER_ID		(CAN_MASTER_NID << CAN_MASTER_NID_MPY)
+
+
+#endif // __BCCI_PARAMS_H


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
    - Добавлена поддержка настройки CAN NodeID при инициализации контроллера и профиля устройства.
    - Реализованы новые действия: сохранение пользовательских данных во флеш-память, восстановление и сброс к заводским значениям.
    - Добавлен новый регистр для хранения CAN NodeID и новый код ошибки для некорректного пароля.
    - Введён отдельный файл с параметрами CAN-интерфейса для гибкой настройки идентификаторов и фильтров.

- **Исправления**
    - Обновлены ограничения NVConstraint для корректной работы с максимальными значениями.

- **Документация**
    - Расширены макросы и описания действий, регистров и ошибок в объектном словаре устройства.

- **Рефакторинг**
    - Изменены интерфейсы инициализации и обработки действий для поддержки новых функций и параметров.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->